### PR TITLE
Added an improved Python implementation.

### DIFF
--- a/wait-for-redis.py
+++ b/wait-for-redis.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+"""
+Usage: python wait_for_redis.py REDISHOST:REDISPORT
+"""
+
+import socket, sys, time
+
+address = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1:6379"
+host, port = address.split(":", 1)
+port = int(port)
+
+def entry_pairs(lines, prefix):
+    """Extract lines "prefixkey:value" as ("key", "value") pairs."""
+    for line in lines:
+        if line.startswith(prefix):
+            yield line[len(prefix):].split(":", 1)
+
+
+print("Waiting for Redis at host {0}, port {1} to complete startup..."
+      .format(host, port))
+sys.stdout.flush()
+
+# Wait for Redis to bind its port.
+
+t0 = time.time()
+while True:
+    try:
+        conn = socket.create_connection((host, port))
+        break
+    except socket.error:
+        pass
+
+    time.sleep(0.1)
+    if time.time() > t0 + 1:
+        t0 = time.time()
+        print("Waiting for Redis to open listening socket.")
+        sys.stdout.flush()
+
+# Wait for Redis to complete loading.
+
+while True:
+    conn.sendall(b"info persistence\r\n")
+    reply = b"".join(iter(lambda: conn.recv(1), b"\n"))
+    if reply.startswith(b"-"):
+        raise SystemExit("Redis: {0}.".format(reply.decode("utf-8").strip()))
+
+    body = conn.recv(int(reply[1:]) + 2).decode("utf-8").splitlines()
+    if "loading:0" in body:
+        print("Redis reports loading completed.")
+        sys.stdout.flush()
+        break
+
+    stats = dict(entry_pairs(body, "loading_"))
+    if time.time() > t0 + 1:
+        t0 = time.time()
+        print("Redis loading dataset, loaded {0}% of {1:.3f} MB, eta {2} s.".format(
+            stats.get("loaded_perc"), int(stats.get("total_bytes", 0.)) / 1024.0**2, stats.get("eta_seconds")))
+        sys.stdout.flush()
+    time.sleep(0.1)
+
+
+print("Redis at host {0}, port {1} completed startup.".format(host, port))
+sys.stdout.flush()


### PR DESCRIPTION
Features:

* Works on Python 2 and 3 (tested on 2.7 and 3.7)
* Connects only once and keeps the socket connected
* No extra library modules (stdlib suffices)
* Suitable as ExecStartPost executable in systemd
* Waits for Redis to open the listening socket
* Shows progress report while loading the dataset

Usable from a systemd.service file, e.g.

```
[Unit]
Description=Redis Database
After=network.target

[Service]
Type=simple
ExecStart=/opt/redis/redis-server /var/local/redis/redis.conf
ExecStartPost=/usr/local/bin/wait-for-redis.py 127.0.0.1:6379
TimeoutStopSec=120
```

Example output:

```
$ python3 wait-for-redis.py localhost:6379
Waiting for Redis at host localhost, port 6379 to complete startup...
Redis loading dataset, loaded 11.10% of 9001.657 MB, eta 72 s.
Redis loading dataset, loaded 22.20% of 9001.657 MB, eta 66 s.
Redis loading dataset, loaded 33.31% of 9001.657 MB, eta 58 s.
Redis loading dataset, loaded 44.42% of 9001.657 MB, eta 47 s.
Redis loading dataset, loaded 55.53% of 9001.657 MB, eta 38 s.
Redis loading dataset, loaded 66.64% of 9001.657 MB, eta 29 s.
Redis loading dataset, loaded 77.74% of 9001.657 MB, eta 18 s.
Redis loading dataset, loaded 88.86% of 9001.657 MB, eta 9 s.
Redis loading dataset, loaded 99.97% of 9001.657 MB, eta 0 s.
Redis reports loading completed.
Redis at host localhost, port 6379 completed startup.
$
```
